### PR TITLE
10月20日から10月31日までの期間で秒数が表示されないバグの修正

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -30,7 +30,7 @@ window.onload = () => {
     }
 
     const endYear =
-      now.getMonth() + 1 > 10 ? now.getFullYear + 1 : now.getFullYear();
+      (now.getMonth() + 1 > 10 || now.getMonth() === 9 && now.getDate() >= 20) ? now.getFullYear() + 1 : now.getFullYear();
     const end = new Date(endYear, 9, 19);
 
     second = (end - now) / 1000;


### PR DESCRIPTION
次の誕生日まで約3000万秒ありますが、今月末まで秒数が正しく計算されていないバグがありましたので修正します。